### PR TITLE
fix: Remove null string shown in markdowntext

### DIFF
--- a/src/Components/NavBar/index.js
+++ b/src/Components/NavBar/index.js
@@ -11,7 +11,7 @@ import SaveChanges from "../SaveChanges";
 const NavBar = ({ showIcon }) => {
   // Handles the click of the trash button and removes the markdown text from local storage.
   const handleTrashClick = () => {
-    localStorage.removeItem("markDownText");
+    localStorage.setItem("markDownText", "");
     window.location.reload();
   };
 


### PR DESCRIPTION
Closes #42 

# Changes

Removing:
`localStorage.removeItem("markDownText");`
Adding:
`localStorage.setItem("markDownText", "");`

null is an object used as a place holder to mean "declared but not assigned". When the trash can icon was clicked, markDownText was no longer assigned and null was passed to markDownText as a placeholder. Setting the keyName to a keyValue of empty parenthesis will no longer show null in the markDownText.

# Testing
* Clicking the trash can should clear all text.
* If markdowntext is cleared, refreshing the page does not generate any new markdowntext like "null".
* If markdowntext is cleared, adding a new markdown feature (h1, h2 etc.) does not pass a string of "null" along with the markdown feature.